### PR TITLE
商品削除機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :correct_user, only: [:edit, :update]
 
   def index
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :correct_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(id: 'DESC')

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if @item.user_id == current_user.id %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only:[:index, :show, :new, :create, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
### What
- destroyメソッド作成
- 商品削除後にトップページに遷移するよう設定

### Why
- 出品商品を削除できるようにするため

### Videos
- ログイン状態の出品者が詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/01721649ae1cacaa969404d79ff36952

- ログイン状態の”非”出品者が詳細ページへ行っても削除ボタンが表示されず削除できない動画
https://gyazo.com/a8a050e1d40e790fd4e1273ea3d7a8f3

- 未ログインユーザーが詳細ページへ行っても削除ボタンが表示されず削除できない動画
https://gyazo.com/7166465bb4a59501ad6fbc6508f2af9d